### PR TITLE
[BUGFIX] Searchbar size on Chrome

### DIFF
--- a/web/graph/global.css
+++ b/web/graph/global.css
@@ -1042,6 +1042,12 @@ input#param.searchfieldreal {
     min-width: 230px;
 }
 
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+    #searchBest{
+      width: 456px;
+    }
+}
+
 #searchBest input, #searchBest select{border:0; max-height:28px}
 
 


### PR DESCRIPTION
The searchbar was not sized on Chrome, because of that, the input was on a new line